### PR TITLE
Fix8 side chain dist filtering

### DIFF
--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -85,12 +85,12 @@ parser.add_argument('--pocket', action='store_true', help='Addition of pocket ba
 
 args = parser.parse_args()
 
-if args.distance_method == ["fraction", "sidechain_fraction"]:
+if args.distance_method in ["fraction", "sidechain_fraction"]:
     if args.fraction is None:
         parser.error("--fraction is required when distance_method is 'fraction' or 'sidechain_fraction")
     distance_threshold = args.fraction
 
-elif args.distance_method == ["value", "sidechain_value"]:
+elif args.distance_method in ["value", "sidechain_value"]:
     if args.value is None:
         parser.error("--value is required when distance_method is 'value' or 'sidechain_fraction")
     distance_threshold = args.value

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -331,8 +331,8 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
             if atoms:
                 residue_atoms[residue_id] = atoms
     if not find_H:
-        print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
-    
+        print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the distance measurements")
+        exit(1)
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index
@@ -478,7 +478,7 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
                 residue_atoms[residue_id] = atoms
     if not find_H:
         print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
-    
+        exit(1)
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -784,14 +784,20 @@ df = filter_on_naccess(PDB, df, access_threshold)
 df = df.dropna(axis=1, how='all')
 df = df.dropna(axis=0, how="all") 
 
+
 if args.distance_method == "fraction":
     df, distance_median = filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file)
 elif args.distance_method == "value":
     df = filter_on_distance_value_biopython(PDB, df, distance_threshold, file)
-elif args.distance_method == "sidechain_fraction":
-    df, distance_median = filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
-elif args.distance_method == "sidechain_value":
-    df = filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold)
+elif args.distance_method in {"sidechain_fraction", "sidechain_value"}:
+    try:
+        if arg.distance_method == "sidechain_fraction":
+            df, distance_median = filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
+        elif args.distance_method == "sidechain_value":
+            df = filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold)
+    except ValueError as error:
+        print(f"Error in sidechain distance filtering:{error}")
+        exit(1)
 
 output_file(df, file)
 

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -33,7 +33,7 @@ from Bio import BiopythonWarning
 warnings.simplefilter('ignore', BiopythonWarning)
 
 #allosigma-filtering -s {pdb_id} -i {up/down}_mutations.tsv 
-                        #-t {dG resultsld} -d {distance threshold} 
+                        #-t {dG thresholdld} -d {distance threshold} 
                         #-a {access threshold}
 
 parser = argparse.ArgumentParser()
@@ -290,10 +290,8 @@ def filter_on_distance_value_biopython(PDB, df, distance_threshold, file):
 def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file):
     """
     A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
-    and creates a dataframe with biopython measuring the minimum distance between 
-    side-chain heavy atoms of each residue pair. For glycine residues, hydrogen 
-    atoms are considered. This is used to filter out sites where the mutational 
-    site is closer than the defined distance_threshold. 
+    and filters out mutation–response site pairs where any side-chain heavy atoms
+    (or glycine sidechain hydrogen atoms) are closer than the defined distance_threshold. 
 
     Parameters
     ----------
@@ -309,99 +307,51 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
 
     """
     pdb_id = op.splitext(PDB)[0]
-    structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]   
-    #define backbone atoms.
-    backbone_atoms = ["CA","C","O","N"]	
-    #define empty list to store results. 
-    distance_data = []  
-    #loop over every residue to compair pairwise distances. 
-    for i, residue_1 in enumerate(structure.get_residues()):
-        #check if the residue is an amino acid (e.g., exclude cofactor).
-        if Bio.PDB.is_aa(residue_1):
-            #check if glycine residue contains H atoms
-            if residue_1.get_resname() == "GLY":
-                find_H = False
-                for atom in residue_1:
-                    if atom.element == "H":
+    structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
+    #dictionary to store residue id and corresponding atom objects
+    residue_atoms = {}
+    #flag to check if the structure has hydrogen atoms
+    find_H = False
+    for residue in structure.get_residues():
+        if Bio.PDB.is_aa(residue):
+            residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
+            #create an list to store atom objects 
+            atoms = []
+            #handle glycine exception
+            if residue.get_resname() == "GLY":
+                for atom in residue:
+                    if atom.element == "H" and atom.get_name().startswith("HA"):
+                        atoms.append(atom)
                         find_H = True
-                        break
-                #prints a warning if glycine does not contain H atoms        
-                if not find_H:
-                    print (f"WARNING: Glycine at postion {residue_1.get_id()[1]} does not contain hydrogen atoms") 
-            for j, residue_2 in enumerate(structure.get_residues()):
-                #check if the residue is an amino acid (e.g., exclude cofactor).
-                if Bio.PDB.is_aa(residue_2):  
-                    #documentation that subtraction measure distance: 
-                    #https://biopython.org/wiki/The_Biopython_Structural_Bioinformatics_FAQ
-                    #under the question: "How do I measure distances?"  
-                    min_distance = float("inf")
-                    #iterates over all atoms in the residue.
-                    for atom_1 in residue_1:
-                        #check for glycine exception.
-                        if residue_1.get_resname() == "GLY":
-                            #check for backbone atoms:
-                            if atom_1.get_name() in backbone_atoms:
-                                #skip backbone atoms.
-                                continue             
-                        #check for the other residues.                         
-                        else:
-                            if atom_1.get_name() in backbone_atoms or atom_1.element == "H":
-                                #skip backbone or hydrogen atom.
-                                continue
-                        #iterates over all atoms in the residue.
-                        for atom_2 in residue_2:
-                            #check for glycine exception.
-                            if residue_2.get_resname() == "GLY":
-                                #check for backbone atoms.
-                                if atom_2.get_name() in backbone_atoms:
-                                    #skip backbone atoms.
-                                    continue                            
-                            #check for the other residues.
-                            else:
-                                #check for backbone or hydrogen atoms.
-                                if atom_2.get_name() in backbone_atoms or atom_2.element == "H":
-                                    #skip backbone or hydrogen atom.
-                                    continue
-                            #compute distance. 
-                            distance = atom_1 - atom_2
-                            #keep the minimum distance between any pair of side-chain heavy atoms. 
-                            if distance < min_distance:
-                                min_distance = distance
-                    res_1 = f"{seq1(residue_1.get_resname())}{residue_1.get_id()[1]}"
-                    res_2 = f"{seq1(residue_2.get_resname())}{residue_2.get_id()[1]}"
-                    if min_distance != float("inf"):
-                        distance_data.append((res_1, res_2,(min_distance)))
-                    else:
-                        print(f"SKIPPED: No valid atoms between {res_1} and {res_2}")
-    #convert to a pandas dataframe. 
-    distance_df = pd.DataFrame(distance_data, columns=["res1", "res2", "distance"])
-    #reduce distance_df to include only the residues close to each other 
-    #within the distance_threshold:
-    distance_df_close = distance_df[distance_df.distance <= distance_threshold]
-    #res1   res2    distance
-    #W91    W91     0.0
-    #W91    P92     2.3
-    #Add a column to the df with the position of the mutation.
+            else:
+                for atom in residue:
+                    if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
+                        atoms.append(atom)
+            if atoms:
+                residue_atoms[residue_id] = atoms
+    if not find_H:
+        print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
+    
+    #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index
     df = df.reset_index()
-    df.set_index('position', inplace=True)    
-    #we iterate over distance_df because it is much more computationally 
-    #cheap to iterate over the smaller dataframe. 
-    for index, row in distance_df_close.iterrows():
-        if row['res1'] in df.index and row['res2'] in df.columns: 
-            df.loc[row['res1'], row['res2']] = np.nan
-            #we continue to use np.nan due as explained above.
-    #remove the position and reinstate mutations as the index.
-    df = df.set_index('mutations', drop=True)
-    
-    #check if all where removed or continue the filtering.
-    if df.isna().all().all():
-        print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
-        exit(1)
-    else:
-        print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
-        return df   
+    df.set_index('position', inplace=True)
+    #iterates over the df checking for non-NaN entries  
+    for mutation_site in df.index:
+        for response_site in df.columns:
+            if pd.isna(df.loc[mutation_site, response_site]):
+                continue
+            atoms1 = residue_atoms.get(mutation_site)
+            atoms2 = residue_atoms.get(response_site)
+            #chek for no empty list
+            if atoms1 and atoms2:
+                #check all atom pairs until finds distance below thredshold 
+                if any((a1-a2) < distance_threshold for a1 in atoms1 for a2 in atoms2):
+                    #sets value to NaN
+                    df.loc[mutation_site, response_site] = np.nan                                 
+    #restore original index
+    df = df.reset_index().set_index('mutations')                
 
 def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
     """
@@ -497,102 +447,32 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold,
     """
     pdb_id = op.splitext(PDB)[0]
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
-    #define backbone atoms.
-    backbone_atoms = ["CA","C","O","N"]
-    #define empty list to store results.
-    distance_data = []
-    #loop over every residue to compair pairwise distances.
-    for i, residue_1 in enumerate(structure.get_residues()):
-        #check if the residue is an amino acid (e.g., exclude cofactor).
-        if Bio.PDB.is_aa(residue_1):
-            #check if glycine residue contains H atoms
-            if residue_1.get_resname() == "GLY":
-                find_H = False
-                for atom in residue_1:
-                    if atom.element == "H":
+    #dictionary to store residue id and atoms coordinates
+    residue_atoms = {}
+    #check if the structure has H atoms
+    find_H = False
+
+    for residue in structure.get_residues():
+        if Bio.PDB.is_aa(residue):
+            residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
+            #create an empty list to store atom coordinates
+            atoms = []
+            #checks for glycine exception
+            if residue.get_resname() == "GLY":
+                for atom in residue:
+                    if atom.element == "H" and atom.get_name().startswith("HA"):
+                        atoms.append(atom)
                         find_H = True
-                        break
-                #prints a warning if glycine does not contain H atoms
-                if not find_H:
-                    print (f"WARNING: Glycine at postion {residue_1.get_id()[1]} does not contain hydrogen atoms")
-            for j, residue_2 in enumerate(structure.get_residues()):
-                #check if the residue is an amino acid (e.g., exclude cofactor).
-                if Bio.PDB.is_aa(residue_2):
-                    #documentation that subtraction measure distance:
-                    #https://biopython.org/wiki/The_Biopython_Structural_Bioinformatics_FAQ
-                    #under the question: "How do I measure distances?"
-                    min_distance = float("inf")
-                    #iterates over all atoms in the residue.
-                    for atom_1 in residue_1:
-                        #check for glycine exception.
-                        if residue_1.get_resname() == "GLY":
-                            #check for backbone atoms:
-                            if atom_1.get_name() in backbone_atoms:
-                                # skip backbone atoms.
-                                continue
-                        #check for the other residues.
-                        else:
-                            if atom_1.get_name() in backbone_atoms or atom_1.element == "H":
-                                #skip backbone or hydrogen atom.
-                                continue
-                        #iterates over all atoms in the residue.
-                        for atom_2 in residue_2:
-                            #check for glycine exception.
-                            if residue_2.get_resname() == "GLY":
-                                #check for backbone atoms.
-                                if atom_2.get_name() in backbone_atoms:
-                                    #skip backbone atoms.
-                                    continue
-                            #check for the other residues.
-                            else:
-                                #check for backbone or hydrogen atoms.
-                                if atom_2.get_name() in backbone_atoms or atom_2.element == "H":
-                                    #skip backbone or hydrogen atom.
-                                    continue
-                            #compute distance.
-                            distance = atom_1 - atom_2
-                            #keep the minimum distance between any pair of side-chain heavy atoms.
-                            if distance < min_distance:
-                                min_distance = distance
-                    res_1 = f"{seq1(residue_1.get_resname())}{residue_1.get_id()[1]}"
-                    res_2 = f"{seq1(residue_2.get_resname())}{residue_2.get_id()[1]}"
-                    if min_distance != float("inf"):
-                        distance_data.append((res_1, res_2,(min_distance)))
-                    else:
-                        print(f"SKIPPED: No valid atoms between {res_1} and {res_2}")
-    #convert to a pandas dataframe.
-    distance_df = pd.DataFrame(distance_data, columns=["res1", "res2", "distance"])
-    distance_median = distance_df.distance.median()
-    threshold = distance_median * distance_threshold
-    print(f"Median Distance is {distance_median}, hence choosen distance is {distance_median*distance_threshold}")
-    #reduce distance_df to include only the residues close to each other
-    #withon the distance_threshold:
-    distance_df_close = distance_df[distance_df.distance <= threshold]
-    #res1   res2    distance
-    #W91    W91     0.0
-    #W91    P92     2.3
-    #Add a column to the df with the position of the mutation.
-    df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
-    #use this as a index
-    df = df.reset_index()
-    df.set_index('position', inplace=True)
-    #we iterate over distance_df because it is much more computationally
-    #cheap to iterate over the smaller dataframe.
-    for index, row in distance_df_close.iterrows():
-        if row['res1'] in df.index and row['res2'] in df.columns:
-            df.loc[row['res1'], row['res2']] = np.nan
-            #we continie to use np.nan due as explained above.
-    #remove the position and reinstate mutations as the index.
-    df = df.set_index('mutations', drop=True)
+            else:
+                for atom in residue:
+                    if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
+                        atoms.append(atom)
+            if atoms:
+                residue_atoms[residue_id] = atoms
+    if not find_H:
+        print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
 
-    #check if all where removed or continue the filtering.
-    if df.isna().all().all():
-        print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
-        exit(1)
-    else:
-        print(f"Filtered successfully on distance, removing sites closer than {distance_median*distance_threshold} Å.")
-        return df, distance_median
-
+    
 def filter_on_naccess(PDB, df, access_threshold):
     """
     A function that takes the PDB file and the dataframe produced by 
@@ -856,4 +736,4 @@ if args.pocket:
 if args.interface: 
     interface_file = args.interface
     interface_analysis(df, file, interface_file, PDB)
-    
+

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -359,7 +359,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                     #sets value to NaN
                     df.loc[res1, res2] = np.nan                                 
     #remove the position and reinstance mutations as the index
-    df = df.set _index('mutations', drop=True)                
+    df = df.set_index('mutations', drop=True)                
     
     #check if all where removed or continue the filtering.
     if df.isna().all().all():

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -308,9 +308,12 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
     """
     pdb_id = op.splitext(PDB)[0]
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
+    #check if the structure contains only one chain
+    if sum(1 for chain in structure.get_chains()) != 1:
+        raise ValueError("Only single-chain structures can be supported.")
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    for residue in structure.get_residues(-:
+    for residue in structure.get_residues():
         if not Bio.PDB.is_aa(residue):
             continue
         #list to store atom objects 
@@ -319,8 +322,10 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
         if residue.get_resname() == "GLY":
             H_atoms = [atom for atom in residue if atom.get_name() in {"HA2","HA3"}]
             if len(H_atoms) != 2:
-                print("WARNING: Incomplete structure, glycine missing H. Exiting...")
-                exit(1)
+                raise ValueError(
+                    f"Incomplete structure. Glycine at position "
+                    f"residue.get_id()[1]} is missing H atoms."
+                    )
             atoms.extend(H_atoms)
         #handle rest of the residues
         else:              
@@ -328,8 +333,10 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                 if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
                     atoms.append(atom)
                 if not atoms:
-                    print("WARNING: Incomplete structure, residue missing side-chain atoms. Exiting...")
-                    exit(1)
+                    raise ValueError
+                        f"Incomplete structure. Residue at position "
+                        f"{residue.get_id()[1]} is missing side-chain atoms."
+                        )
         #store residue ID and atoms
         residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
         residue_atoms[residue_id] = atoms
@@ -455,9 +462,38 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
     """
     pdb_id = op.splitext(PDB)[0]
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
+    #check if the structure contains only one chain
+    if sum(1 for chain in structure.get_chains()) != 1:
+        raise ValueError("Only single-chain structures can be supported.")
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    
+    for residue in structure.get_residues():
+        if not Bio.PDB.is_aa(residue):
+            continue
+        #list to store atom objects
+        atoms = []
+        #handle glycine exception
+        if residue.get_resname() == "GLY":
+            H_atoms = [atom for atom in residue if atom.get_name() in {"HA2","HA3"}]
+            if len(H_atoms) != 2:
+                raise ValueError(
+                    f"Incomplete structure. Glycine at position "
+                    f"residue.get_id()[1]} is missing H atoms."
+                    )
+            atoms.extend(H_atoms)
+        #handle rest of the residues
+        else:
+            for atom in residue:
+                if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
+                    atoms.append(atom)
+                if not atoms:
+                    raise ValueError
+                        f"Incomplete structure. Residue at position "
+                        f"{residue.get_id()[1]} is missing side-chain atoms."
+                        )
+        #store residue ID and atoms
+        residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
+        residue_atoms[residue_id] = atoms
 
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -324,7 +324,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
             if len(H_atoms) != 2:
                 raise ValueError(
                     f"Incomplete structure. Glycine at position "
-                    f"residue.get_id()[1]} is missing H atoms."
+                    f"{residue.get_id()[1]} is missing H atoms."
                     )
             atoms.extend(H_atoms)
         #handle rest of the residues
@@ -332,13 +332,13 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
             for atom in residue:
                 if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
                     atoms.append(atom)
-                if not atoms:
-                    raise ValueError
-                        f"Incomplete structure. Residue at position "
-                        f"{residue.get_id()[1]} is missing side-chain atoms."
-                        )
+            if not atoms:
+                raise ValueError(
+                    f"Incomplete structure. Residue at position "
+                    f"{residue.get_id()[1]} is missing side-chain atoms."
+                    )
         #store residue ID and atoms
-        residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
+        residue_id = f"{Bio.PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
         residue_atoms[residue_id] = atoms
 
     #add a column to the df with the position of the mutation
@@ -478,7 +478,7 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
             if len(H_atoms) != 2:
                 raise ValueError(
                     f"Incomplete structure. Glycine at position "
-                    f"residue.get_id()[1]} is missing H atoms."
+                    f"{residue.get_id()[1]} is missing H atoms."
                     )
             atoms.extend(H_atoms)
         #handle rest of the residues
@@ -486,13 +486,13 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
             for atom in residue:
                 if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
                     atoms.append(atom)
-                if not atoms:
-                    raise ValueError
-                        f"Incomplete structure. Residue at position "
-                        f"{residue.get_id()[1]} is missing side-chain atoms."
-                        )
+            if not atoms:
+                raise ValueError(
+                    f"Incomplete structure. Residue at position "
+                    f"{residue.get_id()[1]} is missing side-chain atoms."
+                    )
         #store residue ID and atoms
-        residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
+        residue_id = f"{Bio.PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
         residue_atoms[residue_id] = atoms
 
     #add a column to the df with the position of the mutation

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -359,13 +359,14 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                 df.loc[res1, res2] = np.nan                                 
     #remove the position and reinstance mutations as the index
     df = df.set_index('mutations', drop=True)                
+    #drop columns and rows where there are no values.
+    df = df.dropna(axis=1, how="all")
+    df = df.dropna(axis=0, how="all")
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
         exit(1)
-    else:
-        df = df.dropna(axis=1, how="all")
-        df = df.dropna(axis=0, how="all")        
+    else:       
         print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
         return df
 
@@ -526,13 +527,14 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
             df.loc[res1, res2] = np.nan
     #remove the position and reset mutations as the index
     df = df.set_index('mutations', drop=True)
+    #drop columns and rows where there are no values.
+    df = df.dropna(axis=1, how="all")
+    df = df.dropna(axis=0, how="all")
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
         exit(1)
     else:
-        df = df.dropna(axis=1, how="all")
-        df = df.dropna(axis=0, how="all")
         print(f"Filtered successfully on distance, removing sites closer than {threshold} Å.")
         return df, distance_median
 

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -309,7 +309,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
     pdb_id = op.splitext(PDB)[0]
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #check if the structure contains only one chain
-    if sum(1 for chain in structure.get_chains()) != 1:
+    if len(list(structure.get_chains())) != 1:
         raise ValueError("Only single-chain structures can be supported.")
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
@@ -463,7 +463,7 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
     pdb_id = op.splitext(PDB)[0]
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #check if the structure contains only one chain
-    if sum(1 for chain in structure.get_chains()) != 1:
+    if len(list(structure.get_chains())) != 1:
         raise ValueError("Only single-chain structures can be supported.")
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -310,19 +310,23 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    #flag to check if the structure has hydrogen atoms
-    find_H = False
+    #flag to check if all glycines have hydrogen atoms
+    all_gly_have_H = True
     for residue in structure.get_residues():
         if Bio.PDB.is_aa(residue):
             residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #create a list to store atom objects 
+            #list to store atom objects 
             atoms = []
             #handle glycine exception
             if residue.get_resname() == "GLY":
+                #flag to check if each glycine has hydrogen atoms 
+                find_H = False
                 for atom in residue:
                     if atom.get_name().startswith("HA"):
                         atoms.append(atom)
                         find_H = True
+                if not find_H:
+                    all_gly_have_H = False
             #handle rest of the residues
             else:
                 for atom in residue:
@@ -330,9 +334,11 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                         atoms.append(atom)
             if atoms:
                 residue_atoms[residue_id] = atoms
-    if not find_H:
-        print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the distance measurements")
+    #exit if any glycine its missing its hydrogen atoms
+    if not all_gly_have_H:
+        print("WARNING: One or more glycines are missing hydrogen atoms. Exiting...")
         exit(1)
+
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index
@@ -456,19 +462,23 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    #flag to check if the structure has hydrogen atoms
-    find_H = False
+    #flag to check if all glycines have hydrogen atoms
+    all_gly_have_H = True
     for residue in structure.get_residues():
         if Bio.PDB.is_aa(residue):
             residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #create a list to store atom objects
+            #list to store atom objects
             atoms = []
             #handle glycine exception
             if residue.get_resname() == "GLY":
+                #flag to check if each glycine has hydrogen atoms
+                find_H = False
                 for atom in residue:
                     if atom.get_name().startswith("HA"):
                         atoms.append(atom)
                         find_H = True
+                if not find_H:
+                    all_gly_have_H = False
             #handle rest of the residues
             else:
                 for atom in residue:
@@ -476,9 +486,11 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
                         atoms.append(atom)
             if atoms:
                 residue_atoms[residue_id] = atoms
-    if not find_H:
-        print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
+    #exit if any glycine is missing its hydrogen atoms
+    if not all_gly_have_H:
+        print("WARNING: One or more glycines are missing hydrogen atoms. Exiting...")
         exit(1)
+
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -57,7 +57,7 @@ parser.add_argument("-t", '--threshold',
                     help='The minimum value threshold for dG values in kcal/mol, integer')
 
 parser.add_argument("-d", "--distance_method",
-                    choices=["fraction", "value"],
+                    choices=["fraction", "value","sidechain_fraction","sidechain_value"],
                     required=True,
                     help="Choose the method for setting the threshold: 'fraction' or 'value'")
 
@@ -85,14 +85,14 @@ parser.add_argument('--pocket', action='store_true', help='Addition of pocket ba
 
 args = parser.parse_args()
 
-if args.distance_method == "fraction":
+if args.distance_method == ["fraction", "sidechain_fraction"]:
     if args.fraction is None:
-        parser.error("--fraction is required when distance_method is 'fraction'")
+        parser.error("--fraction is required when distance_method is 'fraction' or 'sidechain_fraction")
     distance_threshold = args.fraction
 
-elif args.distance_method == "value":
+elif args.distance_method == ["value", "sidechain_value"]:
     if args.value is None:
-        parser.error("--value is required when distance_method is 'value'")
+        parser.error("--value is required when distance_method is 'value' or 'sidechain_fraction")
     distance_threshold = args.value
 
 dg_threshold = args.threshold  
@@ -395,8 +395,6 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
     #remove the position and reinstate mutations as the index.
     df = df.set_index('mutations', drop=True)
     
-    create_arginine_list(df, distance_df, PDB, file)
-    
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
@@ -586,8 +584,6 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold,
             #we continie to use np.nan due as explained above.
     #remove the position and reinstate mutations as the index.
     df = df.set_index('mutations', drop=True)
-
-    create_arginine_list(df, distance_df, PDB, file)
 
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
@@ -847,6 +843,10 @@ if args.distance_method == "fraction":
     df, distance_median = filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file)
 elif args.distance_method == "value":
     df = filter_on_distance_value_biopython(PDB, df, distance_threshold, file)
+elif args.distance_method == "sidechain_fraction":
+    df, distance_median = filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold, file)
+elif args.distance_method == "sidechain_value":
+    df = filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file)
 
 output_file(df, file)
 

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -310,7 +310,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    for residue in structure.get_residues():
+    for residue in structure.get_residues(-:
         if not Bio.PDB.is_aa(residue):
             continue
         #list to store atom objects 
@@ -323,14 +323,17 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                 exit(1)
             atoms.extend(H_atoms)
         #handle rest of the residues
-        else:
+        else:              
             for atom in residue:
                 if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
                     atoms.append(atom)
-        if atoms:
-            residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
-            residue_atoms[residue_id] = atoms
-    
+                if not atoms:
+                    print("WARNING: Incomplete structure, residue missing side-chain atoms. Exiting...")
+                    exit(1)
+        #store residue ID and atoms
+        residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
+        residue_atoms[residue_id] = atoms
+
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -310,35 +310,27 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    #flag to check if all glycines have hydrogen atoms
-    all_gly_have_H = True
     for residue in structure.get_residues():
-        if Bio.PDB.is_aa(residue):
-            residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #list to store atom objects 
-            atoms = []
-            #handle glycine exception
-            if residue.get_resname() == "GLY":
-                #flag to check if each glycine has hydrogen atoms 
-                find_H = False
-                for atom in residue:
-                    if atom.get_name().startswith("HA"):
-                        atoms.append(atom)
-                        find_H = True
-                if not find_H:
-                    all_gly_have_H = False
-            #handle rest of the residues
-            else:
-                for atom in residue:
-                    if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
-                        atoms.append(atom)
-            if atoms:
-                residue_atoms[residue_id] = atoms
-    #exit if any glycine its missing its hydrogen atoms
-    if not all_gly_have_H:
-        print("WARNING: One or more glycines are missing hydrogen atoms. Exiting...")
-        exit(1)
-
+        if not Bio.PDB.is_aa(residue):
+            continue
+        #list to store atom objects 
+        atoms = []
+        #handle glycine exception
+        if residue.get_resname() == "GLY":
+            H_atoms = [atom for atom in residue if atom.get_name() in {"HA2","HA3"}]
+            if len(H_atoms) != 2:
+                print("WARNING: Incomplete structure, glycine missing H. Exiting...")
+                exit(1)
+            atoms.extend(H_atoms)
+        #handle rest of the residues
+        else:
+            for atom in residue:
+                if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
+                    atoms.append(atom)
+        if atoms:
+            residue_id = f"{PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
+            residue_atoms[residue_id] = atoms
+    
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index
@@ -357,7 +349,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                     #sets value to NaN
                     df.loc[res1, res2] = np.nan                                 
     #remove the position and reinstance mutations as the index
-    df = df.set_index('mutations', drop=True)                
+    df = df.set _index('mutations', drop=True)                
     
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
@@ -462,34 +454,7 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
     #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    #flag to check if all glycines have hydrogen atoms
-    all_gly_have_H = True
-    for residue in structure.get_residues():
-        if Bio.PDB.is_aa(residue):
-            residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #list to store atom objects
-            atoms = []
-            #handle glycine exception
-            if residue.get_resname() == "GLY":
-                #flag to check if each glycine has hydrogen atoms
-                find_H = False
-                for atom in residue:
-                    if atom.get_name().startswith("HA"):
-                        atoms.append(atom)
-                        find_H = True
-                if not find_H:
-                    all_gly_have_H = False
-            #handle rest of the residues
-            else:
-                for atom in residue:
-                    if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
-                        atoms.append(atom)
-            if atoms:
-                residue_atoms[residue_id] = atoms
-    #exit if any glycine is missing its hydrogen atoms
-    if not all_gly_have_H:
-        print("WARNING: One or more glycines are missing hydrogen atoms. Exiting...")
-        exit(1)
+    
 
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -33,7 +33,7 @@ from Bio import BiopythonWarning
 warnings.simplefilter('ignore', BiopythonWarning)
 
 #allosigma-filtering -s {pdb_id} -i {up/down}_mutations.tsv 
-                        #-t {dG threshold} -d {distance threshold} 
+                        #-t {dG resultsld} -d {distance threshold} 
                         #-a {access threshold}
 
 parser = argparse.ArgumentParser()
@@ -285,8 +285,126 @@ def filter_on_distance_value_biopython(PDB, df, distance_threshold, file):
         exit(1)
     else:
         print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
-        return df   
+        return df
+
+def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file):
+    """
+    A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
+    and creates a dataframe with biopython measuring the minimum distance between 
+    side-chain heavy atoms of each residue pair. For glycine residues, hydrogen 
+    atoms are considered. This is used to filter out sites where the mutational 
+    site is closer than the defined distance_threshold. 
+
+    Parameters
+    ----------
+    df : A dataframe of mutations (x) and sites (y) with the allosigma
+    calculated dG score is larger than the dG threshold.
+    PDB : The PDB file name
+    disance_threshold: A float or integer that determines the minimum 
+    distance a long-range mutation is allowed to be.
+
+    Returns
+    -------
+    df : A dataframe where the local connection values are excluded.
+
+    """
+    pdb_id = op.splitext(PDB)[0]
+    structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]   
+    #define backbone atoms.
+    backbone_atoms = ["CA","C","O","N"]	
+    #define empty list to store results. 
+    distance_data = []  
+    #loop over every residue to compair pairwise distances. 
+    for i, residue_1 in enumerate(structure.get_residues()):
+        #check if the residue is an amino acid (e.g., exclude cofactor).
+        if Bio.PDB.is_aa(residue_1):
+            #check if glycine residue contains H atoms
+            if residue_1.get_resname() == "GLY":
+                find_H = False
+                for atom in residue_1:
+                    if atom.element == "H":
+                        find_H = True
+                        break
+                #prints a warning if glycine does not contain H atoms        
+                if not find_H:
+                    print (f"WARNING: Glycine at postion {residue_1.get_id()[1]} does not contain hydrogen atoms") 
+            for j, residue_2 in enumerate(structure.get_residues()):
+                #check if the residue is an amino acid (e.g., exclude cofactor).
+                if Bio.PDB.is_aa(residue_2):  
+                    #documentation that subtraction measure distance: 
+                    #https://biopython.org/wiki/The_Biopython_Structural_Bioinformatics_FAQ
+                    #under the question: "How do I measure distances?"  
+                    min_distance = float("inf")
+                    #iterates over all atoms in the residue.
+                    for atom_1 in residue_1:
+                        #check for glycine exception.
+                        if residue_1.get_resname() == "GLY":
+                            #check for backbone atoms:
+                            if atom_1.get_name() in backbone_atoms:
+                                #skip backbone atoms.
+                                continue             
+                        #check for the other residues.                         
+                        else:
+                            if atom_1.get_name() in backbone_atoms or atom_1.element == "H":
+                                #skip backbone or hydrogen atom.
+                                continue
+                        #iterates over all atoms in the residue.
+                        for atom_2 in residue_2:
+                            #check for glycine exception.
+                            if residue_2.get_resname() == "GLY":
+                                #check for backbone atoms.
+                                if atom_2.get_name() in backbone_atoms:
+                                    #skip backbone atoms.
+                                    continue                            
+                            #check for the other residues.
+                            else:
+                                #check for backbone or hydrogen atoms.
+                                if atom_2.get_name() in backbone_atoms or atom_2.element == "H":
+                                    #skip backbone or hydrogen atom.
+                                    continue
+                            #compute distance. 
+                            distance = atom_1 - atom_2
+                            #keep the minimum distance between any pair of side-chain heavy atoms. 
+                            if distance < min_distance:
+                                min_distance = distance
+                    res_1 = f"{seq1(residue_1.get_resname())}{residue_1.get_id()[1]}"
+                    res_2 = f"{seq1(residue_2.get_resname())}{residue_2.get_id()[1]}"
+                    if min_distance != float("inf"):
+                        distance_data.append((res_1, res_2,(min_distance)))
+                    else:
+                        print(f"SKIPPED: No valid atoms between {res_1} and {res_2}")
+    #convert to a pandas dataframe. 
+    distance_df = pd.DataFrame(distance_data, columns=["res1", "res2", "distance"])
+    #reduce distance_df to include only the residues close to each other 
+    #within the distance_threshold:
+    distance_df_close = distance_df[distance_df.distance <= distance_threshold]
+    #res1   res2    distance
+    #W91    W91     0.0
+    #W91    P92     2.3
+    #Add a column to the df with the position of the mutation.
+    df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
+    #use this as a index
+    df = df.reset_index()
+    df.set_index('position', inplace=True)    
+    #we iterate over distance_df because it is much more computationally 
+    #cheap to iterate over the smaller dataframe. 
+    for index, row in distance_df_close.iterrows():
+        if row['res1'] in df.index and row['res2'] in df.columns: 
+            df.loc[row['res1'], row['res2']] = np.nan
+            #we continue to use np.nan due as explained above.
+    #remove the position and reinstate mutations as the index.
+    df = df.set_index('mutations', drop=True)
     
+    create_arginine_list(df, distance_df, PDB, file)
+    
+    #check if all where removed or continue the filtering.
+    if df.isna().all().all():
+        print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
+        exit(1)
+    else:
+        print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
+        return df   
+
 def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
     """
     A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
@@ -351,6 +469,126 @@ def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
     
     create_arginine_list(df, distance_df, PDB, file)
     
+    #check if all where removed or continue the filtering.
+    if df.isna().all().all():
+        print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
+        exit(1)
+    else:
+        print(f"Filtered successfully on distance, removing sites closer than {distance_median*distance_threshold} Å.")
+        return df, distance_median
+
+def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold, file):
+    """
+    A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
+    and creates a dataframe with biopython measuring in CA distances. This is
+    used to filter out sites where the mutational site is closer than the
+    defined distance_threshold.
+
+    Parameters
+    ----------
+    df : A dataframe of mutations (x) and sites (y) with the allosigma
+    calculated dG score is larger than the dG threshold.
+    PDB : The PDB file name
+    disance_threshold: A float or integer that determines the minimum
+    distance a long-range mutation is allowed to be.
+
+    Returns
+    -------
+    df : A dataframe where the local connection values are excluded.
+
+    """
+    pdb_id = op.splitext(PDB)[0]
+    structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
+    #define backbone atoms.
+    backbone_atoms = ["CA","C","O","N"]
+    #define empty list to store results.
+    distance_data = []
+    #loop over every residue to compair pairwise distances.
+    for i, residue_1 in enumerate(structure.get_residues()):
+        #check if the residue is an amino acid (e.g., exclude cofactor).
+        if Bio.PDB.is_aa(residue_1):
+            #check if glycine residue contains H atoms
+            if residue_1.get_resname() == "GLY":
+                find_H = False
+                for atom in residue_1:
+                    if atom.element == "H":
+                        find_H = True
+                        break
+                #prints a warning if glycine does not contain H atoms
+                if not find_H:
+                    print (f"WARNING: Glycine at postion {residue_1.get_id()[1]} does not contain hydrogen atoms")
+            for j, residue_2 in enumerate(structure.get_residues()):
+                #check if the residue is an amino acid (e.g., exclude cofactor).
+                if Bio.PDB.is_aa(residue_2):
+                    #documentation that subtraction measure distance:
+                    #https://biopython.org/wiki/The_Biopython_Structural_Bioinformatics_FAQ
+                    #under the question: "How do I measure distances?"
+                    min_distance = float("inf")
+                    #iterates over all atoms in the residue.
+                    for atom_1 in residue_1:
+                        #check for glycine exception.
+                        if residue_1.get_resname() == "GLY":
+                            #check for backbone atoms:
+                            if atom_1.get_name() in backbone_atoms:
+                                # skip backbone atoms.
+                                continue
+                        #check for the other residues.
+                        else:
+                            if atom_1.get_name() in backbone_atoms or atom_1.element == "H":
+                                #skip backbone or hydrogen atom.
+                                continue
+                        #iterates over all atoms in the residue.
+                        for atom_2 in residue_2:
+                            #check for glycine exception.
+                            if residue_2.get_resname() == "GLY":
+                                #check for backbone atoms.
+                                if atom_2.get_name() in backbone_atoms:
+                                    #skip backbone atoms.
+                                    continue
+                            #check for the other residues.
+                            else:
+                                #check for backbone or hydrogen atoms.
+                                if atom_2.get_name() in backbone_atoms or atom_2.element == "H":
+                                    #skip backbone or hydrogen atom.
+                                    continue
+                            #compute distance.
+                            distance = atom_1 - atom_2
+                            #keep the minimum distance between any pair of side-chain heavy atoms.
+                            if distance < min_distance:
+                                min_distance = distance
+                    res_1 = f"{seq1(residue_1.get_resname())}{residue_1.get_id()[1]}"
+                    res_2 = f"{seq1(residue_2.get_resname())}{residue_2.get_id()[1]}"
+                    if min_distance != float("inf"):
+                        distance_data.append((res_1, res_2,(min_distance)))
+                    else:
+                        print(f"SKIPPED: No valid atoms between {res_1} and {res_2}")
+    #convert to a pandas dataframe.
+    distance_df = pd.DataFrame(distance_data, columns=["res1", "res2", "distance"])
+    distance_median = distance_df.distance.median()
+    threshold = distance_median * distance_threshold
+    print(f"Median Distance is {distance_median}, hence choosen distance is {distance_median*distance_threshold}")
+    #reduce distance_df to include only the residues close to each other
+    #withon the distance_threshold:
+    distance_df_close = distance_df[distance_df.distance <= threshold]
+    #res1   res2    distance
+    #W91    W91     0.0
+    #W91    P92     2.3
+    #Add a column to the df with the position of the mutation.
+    df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
+    #use this as a index
+    df = df.reset_index()
+    df.set_index('position', inplace=True)
+    #we iterate over distance_df because it is much more computationally
+    #cheap to iterate over the smaller dataframe.
+    for index, row in distance_df_close.iterrows():
+        if row['res1'] in df.index and row['res2'] in df.columns:
+            df.loc[row['res1'], row['res2']] = np.nan
+            #we continie to use np.nan due as explained above.
+    #remove the position and reinstate mutations as the index.
+    df = df.set_index('mutations', drop=True)
+
+    create_arginine_list(df, distance_df, PDB, file)
+
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -351,8 +351,8 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
         for res2 in df.columns:
             if pd.isna(df.loc[res1, res2]):
                 continue
-            atoms1 = residue_atoms.get(res1)
-            atoms2 = residue_atoms.get(res2)
+            atoms1 = residue_atoms[res1]
+            atoms2 = residue_atoms[res2]
             #check all atom pairs until finds distance below threshold 
             if any((a1 - a2) <= distance_threshold for a1 in atoms1 for a2 in atoms2):
                 #sets value to NaN
@@ -508,8 +508,8 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
             if pd.isna(df.loc[res1, res2]):
                 continue
             #Load atom list for both residues    
-            atoms1 = residue_atoms.get(res1)
-            atoms2 = residue_atoms.get(res2)
+            atoms1 = residue_atoms[res1]
+            atoms2 = residue_atoms[res2]
             #calculate the shortest distance between every atom pair in the 2 residues
             min_distance = min(a1 - a2 for a1 in atoms1 for a2 in atoms2)
             distance_data.append((res1, res2, min_distance))

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -33,7 +33,7 @@ from Bio import BiopythonWarning
 warnings.simplefilter('ignore', BiopythonWarning)
 
 #allosigma-filtering -s {pdb_id} -i {up/down}_mutations.tsv 
-                        #-t {dG thresholdld} -d {distance threshold} 
+                        #-t {dG threshold} -d {distance threshold} 
                         #-a {access threshold}
 
 parser = argparse.ArgumentParser()
@@ -59,7 +59,7 @@ parser.add_argument("-t", '--threshold',
 parser.add_argument("-d", "--distance_method",
                     choices=["fraction", "value","sidechain_fraction","sidechain_value"],
                     required=True,
-                    help="Choose the method for setting the threshold: 'fraction' or 'value'")
+                    help="Choose the method for setting the threshold: 'fraction','value','sidesidechain_fraction','sidechain_value')
 
 parser.add_argument("-f", "--fraction",
                     type=float,
@@ -87,12 +87,12 @@ args = parser.parse_args()
 
 if args.distance_method in ["fraction", "sidechain_fraction"]:
     if args.fraction is None:
-        parser.error("--fraction is required when distance_method is 'fraction' or 'sidechain_fraction")
+        parser.error("--fraction is required when distance_method is 'fraction' or 'sidechain_fraction'")
     distance_threshold = args.fraction
 
 elif args.distance_method in ["value", "sidechain_value"]:
     if args.value is None:
-        parser.error("--value is required when distance_method is 'value' or 'sidechain_fraction")
+        parser.error("--value is required when distance_method is 'value' or 'sidechain_value'")
     distance_threshold = args.value
 
 dg_threshold = args.threshold  
@@ -258,7 +258,7 @@ def filter_on_distance_value_biopython(PDB, df, distance_threshold, file):
     #convert to a pandas dataframe. 
     distance_df = pd.DataFrame(distance_data, columns=["res1", "res2", "distance"])
     #reduce distance_df to include only the residues close to each other 
-    #withon the distance_threshold:
+    #within the distance_threshold:
     distance_df_close = distance_df[distance_df.distance <= distance_threshold]
     #res1   res2    distance
     #W91    W91     0.0
@@ -287,7 +287,7 @@ def filter_on_distance_value_biopython(PDB, df, distance_threshold, file):
         print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
         return df
 
-def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file):
+def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
     """
     A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
     and filters out mutation–response site pairs where any side-chain heavy atoms
@@ -347,7 +347,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
             atoms2 = residue_atoms.get(res2)
             if atoms1 and atoms2:
                 #check all atom pairs until finds distance below threshold 
-                if any((a1 - a2) < distance_threshold for a1 in atoms1 for a2 in atoms2):
+                if any((a1 - a2) <= distance_threshold for a1 in atoms1 for a2 in atoms2):
                     #sets value to NaN
                     df.loc[res1, res2] = np.nan                                 
     #remove the position and reinstance mutations as the index
@@ -404,7 +404,7 @@ def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
     threshold = distance_median * distance_threshold
     print(f"Median Distance is {distance_median}, hence choosen distance is {distance_median*distance_threshold}")
     #reduce distance_df to include only the residues close to each other 
-    #withon the distance_threshold:
+    #within the distance_threshold:
     distance_df_close = distance_df[distance_df.distance <= threshold]
     #res1   res2    distance
     #W91    W91     0.0
@@ -433,7 +433,7 @@ def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
         print(f"Filtered successfully on distance, removing sites closer than {distance_median*distance_threshold} Å.")
         return df, distance_median
 
-def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold, file):
+def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold):
     """
     A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
     and filters out mutation–response site pairs where any side-chain heavy atoms
@@ -504,7 +504,7 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold,
     threshold = distance_median * distance_threshold
     print(f"Median Distance is {distance_median}, hence chosen distance is {threshold}")
     #keep residue pairs closer than the threshold
-    close_distance_data = [d for d in distance_data if d[2]<= threshold]
+    close_distance_data = [d for d in distance_data if d[2] <= threshold]
     #filter out residue pairs that are too close
     for res1, res2, min_distance in close_distance_data:
         if res1 in df.index and res2 in df.columns:
@@ -771,9 +771,9 @@ if args.distance_method == "fraction":
 elif args.distance_method == "value":
     df = filter_on_distance_value_biopython(PDB, df, distance_threshold, file)
 elif args.distance_method == "sidechain_fraction":
-    df, distance_median = filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold, file)
+    df, distance_median = filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
 elif args.distance_method == "sidechain_value":
-    df = filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file)
+    df = filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold)
 
 output_file(df, file)
 

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -298,7 +298,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
     df : A dataframe of mutations (x) and sites (y) with the allosigma
     calculated dG score is larger than the dG threshold.
     PDB : The PDB file name
-    disance_threshold: A float or integer that determines the minimum 
+    distance_threshold: A float or integer that determines the minimum 
     distance a long-range mutation is allowed to be.
 
     Returns
@@ -320,7 +320,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
             #handle glycine exception
             if residue.get_resname() == "GLY":
                 for atom in residue:
-                    if atom.element == "H" and atom.get_name().startswith("HA"):
+                    if atom.get_name().startswith("HA"):
                         atoms.append(atom)
                         find_H = True
             #handle rest of the residues
@@ -345,14 +345,13 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
                 continue
             atoms1 = residue_atoms.get(res1)
             atoms2 = residue_atoms.get(res2)
-            #chek for no empty list
             if atoms1 and atoms2:
                 #check all atom pairs until finds distance below threshold 
                 if any((a1 - a2) < distance_threshold for a1 in atoms1 for a2 in atoms2):
                     #sets value to NaN
                     df.loc[res1, res2] = np.nan                                 
-    #restore original index
-    df = df.reset_index().set_index('mutations')                
+    #remove the position and reinstance mutations as the index
+    df = df.set_index('mutations', drop=True)                
     
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
@@ -434,7 +433,7 @@ def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
         print(f"Filtered successfully on distance, removing sites closer than {distance_median*distance_threshold} Å.")
         return df, distance_median
 
-def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file):
+def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold, file):
     """
     A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
     and filters out mutation–response site pairs where any side-chain heavy atoms
@@ -462,12 +461,12 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
     for residue in structure.get_residues():
         if Bio.PDB.is_aa(residue):
             residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #create an list to store atom objects
+            #create a list to store atom objects
             atoms = []
             #handle glycine exception
             if residue.get_resname() == "GLY":
                 for atom in residue:
-                    if atom.element == "H" and atom.get_name().startswith("HA"):
+                    if atom.get_name().startswith("HA"):
                         atoms.append(atom)
                         find_H = True
             #handle rest of the residues
@@ -479,6 +478,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
                 residue_atoms[residue_id] = atoms
     if not find_H:
         print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
+    
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
     #use this as a index
@@ -509,8 +509,9 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
     for res1, res2, min_distance in close_distance_data:
         if res1 in df.index and res2 in df.columns:
             df.loc[res1, res2] = np.nan
-    #restore original index
-    df = df.reset_index().set_index('mutations')
+    #remove the position and reinstate mutations as the index
+    df = df.set_index('mutations', drop=True)
+
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -59,7 +59,7 @@ parser.add_argument("-t", '--threshold',
 parser.add_argument("-d", "--distance_method",
                     choices=["fraction", "value","sidechain_fraction","sidechain_value"],
                     required=True,
-                    help="Choose the method for setting the threshold: 'fraction','value','sidesidechain_fraction','sidechain_value')
+                    help="Choose the method for setting the threshold:'fraction','value','sidesidechain_fraction','sidechain_value'")
 
 parser.add_argument("-f", "--fraction",
                     type=float,
@@ -353,19 +353,19 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                 continue
             atoms1 = residue_atoms.get(res1)
             atoms2 = residue_atoms.get(res2)
-            if atoms1 and atoms2:
-                #check all atom pairs until finds distance below threshold 
-                if any((a1 - a2) <= distance_threshold for a1 in atoms1 for a2 in atoms2):
-                    #sets value to NaN
-                    df.loc[res1, res2] = np.nan                                 
+            #check all atom pairs until finds distance below threshold 
+            if any((a1 - a2) <= distance_threshold for a1 in atoms1 for a2 in atoms2):
+                #sets value to NaN
+                df.loc[res1, res2] = np.nan                                 
     #remove the position and reinstance mutations as the index
     df = df.set_index('mutations', drop=True)                
-    
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
         exit(1)
     else:
+        df = df.dropna(axis=1, how="all")
+        df = df.dropna(axis=0, how="all")        
         print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
         return df
 
@@ -510,10 +510,9 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
             #Load atom list for both residues    
             atoms1 = residue_atoms.get(res1)
             atoms2 = residue_atoms.get(res2)
-            if atoms1 and atoms2:
-                #calculate the shortest distance between every atom pair in the 2 residues
-                min_distance = min(a1 - a2 for a1 in atoms1 for a2 in atoms2)
-                distance_data.append((res1, res2, min_distance))
+            #calculate the shortest distance between every atom pair in the 2 residues
+            min_distance = min(a1 - a2 for a1 in atoms1 for a2 in atoms2)
+            distance_data.append((res1, res2, min_distance))
     #Calculate the median distance 
     all_min_distance = [d[2] for d in distance_data]
     distance_median = np.median(all_min_distance)
@@ -525,14 +524,15 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
     for res1, res2, min_distance in close_distance_data:
         if res1 in df.index and res2 in df.columns:
             df.loc[res1, res2] = np.nan
-    #remove the position and reinstate mutations as the index
+    #remove the position and reset mutations as the index
     df = df.set_index('mutations', drop=True)
-
     #check if all where removed or continue the filtering.
     if df.isna().all().all():
         print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
         exit(1)
     else:
+        df = df.dropna(axis=1, how="all")
+        df = df.dropna(axis=0, how="all")
         print(f"Filtered successfully on distance, removing sites closer than {threshold} Å.")
         return df, distance_median
 

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -315,7 +315,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
     for residue in structure.get_residues():
         if Bio.PDB.is_aa(residue):
             residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #create an list to store atom objects 
+            #create a list to store atom objects 
             atoms = []
             #handle glycine exception
             if residue.get_resname() == "GLY":
@@ -323,6 +323,7 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
                     if atom.element == "H" and atom.get_name().startswith("HA"):
                         atoms.append(atom)
                         find_H = True
+            #handle rest of the residues
             else:
                 for atom in residue:
                     if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
@@ -338,20 +339,28 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, fi
     df = df.reset_index()
     df.set_index('position', inplace=True)
     #iterates over the df checking for non-NaN entries  
-    for mutation_site in df.index:
-        for response_site in df.columns:
-            if pd.isna(df.loc[mutation_site, response_site]):
+    for res1 in df.index:
+        for res2 in df.columns:
+            if pd.isna(df.loc[res1, res2]):
                 continue
-            atoms1 = residue_atoms.get(mutation_site)
-            atoms2 = residue_atoms.get(response_site)
+            atoms1 = residue_atoms.get(res1)
+            atoms2 = residue_atoms.get(res2)
             #chek for no empty list
             if atoms1 and atoms2:
-                #check all atom pairs until finds distance below thredshold 
-                if any((a1-a2) < distance_threshold for a1 in atoms1 for a2 in atoms2):
+                #check all atom pairs until finds distance below threshold 
+                if any((a1 - a2) < distance_threshold for a1 in atoms1 for a2 in atoms2):
                     #sets value to NaN
-                    df.loc[mutation_site, response_site] = np.nan                                 
+                    df.loc[res1, res2] = np.nan                                 
     #restore original index
     df = df.reset_index().set_index('mutations')                
+    
+    #check if all where removed or continue the filtering.
+    if df.isna().all().all():
+        print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
+        exit(1)
+    else:
+        print(f"Filtered successfully on distance, removing sites closer than {distance_threshold} Å.")
+        return df
 
 def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
     """
@@ -425,44 +434,43 @@ def filter_on_distance_fraction_biopython(PDB, df, distance_threshold, file):
         print(f"Filtered successfully on distance, removing sites closer than {distance_median*distance_threshold} Å.")
         return df, distance_median
 
-def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold, file):
+def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold, file):
     """
     A function that takes the dataframe produced by filter_on_dg(df, dg_threshold)
-    and creates a dataframe with biopython measuring in CA distances. This is
-    used to filter out sites where the mutational site is closer than the
-    defined distance_threshold.
+    and filters out mutation–response site pairs where any side-chain heavy atoms
+    (or glycine sidechain hydrogen atoms) are closer than the defined threshold.
 
     Parameters
     ----------
     df : A dataframe of mutations (x) and sites (y) with the allosigma
     calculated dG score is larger than the dG threshold.
     PDB : The PDB file name
-    disance_threshold: A float or integer that determines the minimum
+    distance_threshold: A float or integer that determines the minimum
     distance a long-range mutation is allowed to be.
 
     Returns
     -------
-    df : A dataframe where the local connection values are excluded.
+    df : A dataframe where the local connection values are excluded (set to NaN).
 
     """
     pdb_id = op.splitext(PDB)[0]
     structure = Bio.PDB.PDBParser().get_structure(pdb_id, PDB)[0]
-    #dictionary to store residue id and atoms coordinates
+    #dictionary to store residue id and corresponding atom objects
     residue_atoms = {}
-    #check if the structure has H atoms
+    #flag to check if the structure has hydrogen atoms
     find_H = False
-
     for residue in structure.get_residues():
         if Bio.PDB.is_aa(residue):
             residue_id = f"{seq1(residue.get_resname())}{residue.get_id()[1]}"
-            #create an empty list to store atom coordinates
+            #create an list to store atom objects
             atoms = []
-            #checks for glycine exception
+            #handle glycine exception
             if residue.get_resname() == "GLY":
                 for atom in residue:
                     if atom.element == "H" and atom.get_name().startswith("HA"):
                         atoms.append(atom)
                         find_H = True
+            #handle rest of the residues
             else:
                 for atom in residue:
                     if atom.element != "H" and atom.get_name() not in {"N", "CA", "C", "O"}:
@@ -471,8 +479,46 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold,
                 residue_atoms[residue_id] = atoms
     if not find_H:
         print("Warning: No hydrogen atoms in the PDB structure. Glycines will be excluded from the pairwise distance measurements")
+    #add a column to the df with the position of the mutation
+    df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
+    #use this as a index
+    df = df.reset_index()
+    df.set_index('position', inplace=True)
+    #calculate minimum distance
+    distance_data = []
+    #iterates over the df checking for non-NaN entries
+    for res1 in df.index:
+        for res2 in df.columns:
+            if pd.isna(df.loc[res1, res2]):
+                continue
+            #Load atom list for both residues    
+            atoms1 = residue_atoms.get(res1)
+            atoms2 = residue_atoms.get(res2)
+            if atoms1 and atoms2:
+                #calculate the shortest distance between every atom pair in the 2 residues
+                min_distance = min(a1 - a2 for a1 in atoms1 for a2 in atoms2)
+                distance_data.append((res1, res2, min_distance))
+    #Calculate the median distance 
+    all_min_distance = [d[2] for d in distance_data]
+    distance_median = np.median(all_min_distance)
+    threshold = distance_median * distance_threshold
+    print(f"Median Distance is {distance_median}, hence chosen distance is {threshold}")
+    #keep residue pairs closer than the threshold
+    close_distance_data = [d for d in distance_data if d[2]<= threshold]
+    #filter out residue pairs that are too close
+    for res1, res2, min_distance in close_distance_data:
+        if res1 in df.index and res2 in df.columns:
+            df.loc[res1, res2] = np.nan
+    #restore original index
+    df = df.reset_index().set_index('mutations')
+    #check if all where removed or continue the filtering.
+    if df.isna().all().all():
+        print("WARNING: No dG filtered mutations satisfy the filtering on distance; Exiting...")
+        exit(1)
+    else:
+        print(f"Filtered successfully on distance, removing sites closer than {threshold} Å.")
+        return df, distance_median
 
-    
 def filter_on_naccess(PDB, df, access_threshold):
     """
     A function that takes the PDB file and the dataframe produced by 

--- a/4a.allosigma_filtering/allosigma-filtering
+++ b/4a.allosigma_filtering/allosigma-filtering
@@ -340,12 +340,14 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
         #store residue ID and atoms
         residue_id = f"{Bio.PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
         residue_atoms[residue_id] = atoms
-
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
-    #use this as a index
+    #turn the index "mutations" into a column 
     df = df.reset_index()
+    #set position as new index
     df.set_index('position', inplace=True)
+    #remove mutations column and store it.
+    mutations_column = df.pop("mutations")
     #iterates over the df checking for non-NaN entries  
     for res1 in df.index:
         for res2 in df.columns:
@@ -358,7 +360,8 @@ def filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold):
                 #sets value to NaN
                 df.loc[res1, res2] = np.nan                                 
     #remove the position and reinstance mutations as the index
-    df = df.set_index('mutations', drop=True)                
+    df["mutations"] = mutations_column.values
+    df.set_index("mutations", inplace=True)
     #drop columns and rows where there are no values.
     df = df.dropna(axis=1, how="all")
     df = df.dropna(axis=0, how="all")
@@ -495,12 +498,14 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
         #store residue ID and atoms
         residue_id = f"{Bio.PDB.Polypeptide.three_to_one(residue.get_resname())}{residue.get_id()[1]}"
         residue_atoms[residue_id] = atoms
-
     #add a column to the df with the position of the mutation
     df['position'] = df.apply(lambda r: r.name.split(' ')[0][:-1], axis=1)
-    #use this as a index
+    #turn the index "mutations" into a column
     df = df.reset_index()
+    #set position as new index
     df.set_index('position', inplace=True)
+    #remove mutations column and store it.
+    mutations_column = df.pop("mutations")    
     #calculate minimum distance
     distance_data = []
     #iterates over the df checking for non-NaN entries
@@ -525,8 +530,9 @@ def filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
     for res1, res2, min_distance in close_distance_data:
         if res1 in df.index and res2 in df.columns:
             df.loc[res1, res2] = np.nan
-    #remove the position and reset mutations as the index
-    df = df.set_index('mutations', drop=True)
+    #remove position column and reinstance mutations as the index
+    df["mutations"] = mutations_column.values
+    df.set_index("mutations", inplace=True)    
     #drop columns and rows where there are no values.
     df = df.dropna(axis=1, how="all")
     df = df.dropna(axis=0, how="all")
@@ -791,7 +797,7 @@ elif args.distance_method == "value":
     df = filter_on_distance_value_biopython(PDB, df, distance_threshold, file)
 elif args.distance_method in {"sidechain_fraction", "sidechain_value"}:
     try:
-        if arg.distance_method == "sidechain_fraction":
+        if args.distance_method == "sidechain_fraction":
             df, distance_median = filter_on_sidechain_distance_fraction_biopython(PDB, df, distance_threshold)
         elif args.distance_method == "sidechain_value":
             df = filter_on_sidechain_distance_value_biopython(PDB, df, distance_threshold)

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ This script takes
 - a dG cutoff value (in kcal/mol)
 - a Distance cutoff: 
 	Two distance calculation methods are available:
-	- Cα–Cα distances 
+	- Cα–Cα distances  
 	- Side-chain heavy atom distances (Glycine uses HA2/HA3) 
-	Each method supports two threshold modes:
+	Each distance method supports two threshold modes:
 	- Value: a specific value (in Å - e.g. 14) 
-	- Faction: a fraction of the median (e.g. 0.9)
+	- Fraction: a fraction of the median (e.g. 0.9)
 	The method and the mode are selected using the -d flag, with four possible options:
 	 Option               | Description                                       | Example                          |
 	|-----------------------|---------------------------------------------------|----------------------------------|

--- a/README.md
+++ b/README.md
@@ -146,7 +146,21 @@ This script takes
 - a PDB file
 - a up or down {}_mutations.tsv file
 - a dG cutoff value (in kcal/mol)
-- a Distance cutoff: either a specific value (in Å - e.g. 14) OR a fraction of the median (e.g. 0.9)
+- a Distance cutoff: 
+	Two distance calculation methods are available:
+	- Cα–Cα distances 
+	- Side-chain heavy atom distances (Glycine uses HA2/HA3) 
+	Each method supports two threshold modes:
+	- Value: a specific value (in Å - e.g. 14) 
+	- Faction: a fraction of the median (e.g. 0.9)
+	The method and the mode are selected using the -d flag, with four possible options:
+	 Option               | Description                                       | Example                          |
+	|-----------------------|---------------------------------------------------|----------------------------------|
+	| `value`               | Cα–Cα distances with fixed cutoff                 | `-d value -v 10`                 |
+	| `fraction`            | Cα–Cα distances as a fraction of median           | `-d fraction -f 0.5`             |
+	| `sidechain_value`     | side-chain atom distances with fixed cutoff       | `-d sidechain_value -v 10`       |
+	| `sidechain_fraction`  | side-chain atom distances as a fraction of median | `-d sidechain_fraction -f 0.5`   |
+
 - an accessibility cutoff value (0-100)
 - Can take the flag --pocket or --interface {file}, if a particular interface is of interest. 
 

--- a/README.md
+++ b/README.md
@@ -146,20 +146,22 @@ This script takes
 - a PDB file
 - a up or down {}_mutations.tsv file
 - a dG cutoff value (in kcal/mol)
-- a Distance cutoff: 
+- a Distance cutoff:  
 	Two distance calculation methods are available:
-	- Cα–Cα distances  
-	- Side-chain heavy atom distances (Glycine uses HA2/HA3) 
+	- Cα–Cα distances: computes the distance between backbone alpha carbon atoms
+	- Side-chain heavy atom distances: computes the shortest distance between any side-chain heavy atoms
+	  (Glycine uses HA2/HA3) 
 	Each distance method supports two threshold modes:
 	- Value: a specific value (in Å - e.g. 14) 
 	- Fraction: a fraction of the median (e.g. 0.9)
 	The method and the mode are selected using the -d flag, with four possible options:
-	 Option               | Description                                       | Example                          |
-	|-----------------------|---------------------------------------------------|----------------------------------|
-	| `value`               | Cα–Cα distances with fixed cutoff                 | `-d value -v 10`                 |
-	| `fraction`            | Cα–Cα distances as a fraction of median           | `-d fraction -f 0.5`             |
-	| `sidechain_value`     | side-chain atom distances with fixed cutoff       | `-d sidechain_value -v 10`       |
-	| `sidechain_fraction`  | side-chain atom distances as a fraction of median | `-d sidechain_fraction -f 0.5`   |
+
+	  Option               | Description                                       | Example                          |
+       |-----------------------|---------------------------------------------------|----------------------------------|
+       | `value`               | Cα–Cα distances with fixed cutoff                 | `-d value -v 10`                 |
+       | `fraction`            | Cα–Cα distances as a fraction of median           | `-d fraction -f 0.5`             |
+       | `sidechain_value`     | side-chain atom distances with fixed cutoff       | `-d sidechain_value -v 10`       |
+       | `sidechain_fraction`  | side-chain atom distances as a fraction of median | `-d sidechain_fraction -f 0.5`   |
 
 - an accessibility cutoff value (0-100)
 - Can take the flag --pocket or --interface {file}, if a particular interface is of interest. 


### PR DESCRIPTION
fixes #8  

Added two new functions for distance filtering:
      > filter_on_sidechain_distance_value_biopython
      > filter_on_sidechain_distance_fraction_biopython
Both functions measure the minimum distance between side-chain heavy atoms for each residue pair. Taking into account glycine exception
Modified argparse CLI logic to support the new distance methods (sidechain_value and sidechain_fraction)

**I just realized there’s a mistake on line 36 — I must’ve changed it without noticing. It should remain as it was: #-t {dG threshold} -d {distance threshold}.**